### PR TITLE
Implement JSON output formatter

### DIFF
--- a/.kiro/specs/dotnet-api-diff/tasks.md
+++ b/.kiro/specs/dotnet-api-diff/tasks.md
@@ -108,7 +108,7 @@ Each task should follow this git workflow:
     - _Requirements: 3.2, 3.3, 5.1, 5.2, 5.3, 5.4_
 
 - [ ] 6. Implement output formatting and reporting
-  - [ ] 6.1 Create ReportGenerator and console output formatter
+  - [x] 6.1 Create ReportGenerator and console output formatter
     - Implement ReportGenerator interface with support for multiple formats
     - Create ConsoleFormatter with colored output for additions, removals, modifications
     - Add summary statistics and breaking change indicators
@@ -116,7 +116,7 @@ Each task should follow this git workflow:
     - **Git Workflow**: Create branch `feature/task-6.1-report-generator`, commit, push, and create PR
     - _Requirements: 4.4, 8.1, 8.4_
 
-  - [ ] 6.2 Implement JSON output formatter
+  - [x] 6.2 Implement JSON output formatter
     - Create JsonFormatter producing structured, valid JSON output
     - Include all comparison details suitable for programmatic consumption
     - Write unit tests validating JSON structure and content

--- a/src/DotNetApiDiff/Reporting/JsonFormatter.cs
+++ b/src/DotNetApiDiff/Reporting/JsonFormatter.cs
@@ -99,8 +99,6 @@ public class JsonFormatter : IReportFormatter
         };
     }
 
-    #region JSON Models
-
     /// <summary>
     /// JSON-specific representation of a comparison result
     /// </summary>
@@ -168,6 +166,4 @@ public class JsonFormatter : IReportFormatter
 
         public string? NewSignature { get; set; }
     }
-
-    #endregion
 }

--- a/src/DotNetApiDiff/Reporting/JsonFormatter.cs
+++ b/src/DotNetApiDiff/Reporting/JsonFormatter.cs
@@ -1,0 +1,151 @@
+// Copyright DotNet API Diff Project Contributors - SPDX Identifier: MIT
+using DotNetApiDiff.Interfaces;
+using DotNetApiDiff.Models;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DotNetApiDiff.Reporting;
+
+/// <summary>
+/// Formatter for JSON output with complete comparison details
+/// </summary>
+public class JsonFormatter : IReportFormatter
+{
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonFormatter"/> class.
+    /// </summary>
+    /// <param name="indented">Whether to format the JSON with indentation</param>
+    public JsonFormatter(bool indented = true)
+    {
+        _jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = indented,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+    }
+
+    /// <summary>
+    /// Formats a comparison result as JSON
+    /// </summary>
+    /// <param name="result">The comparison result to format</param>
+    /// <returns>Formatted JSON output as a string</returns>
+    public string Format(ComparisonResult result)
+    {
+        // Create a JSON-friendly representation of the comparison result
+        var jsonModel = CreateJsonModel(result);
+        
+        // Serialize to JSON
+        return JsonSerializer.Serialize(jsonModel, _jsonOptions);
+    }
+
+    private static JsonComparisonResult CreateJsonModel(ComparisonResult result)
+    {
+        // Create a JSON-specific model that includes all necessary information
+        var jsonResult = new JsonComparisonResult
+        {
+            OldAssemblyPath = result.OldAssemblyPath,
+            NewAssemblyPath = result.NewAssemblyPath,
+            ComparisonTimestamp = result.ComparisonTimestamp,
+            HasBreakingChanges = result.HasBreakingChanges,
+            TotalDifferences = result.TotalDifferences,
+            Summary = new JsonComparisonSummary
+            {
+                AddedCount = result.Summary.AddedCount,
+                RemovedCount = result.Summary.RemovedCount,
+                ModifiedCount = result.Summary.ModifiedCount,
+                BreakingChangesCount = result.Summary.BreakingChangesCount,
+                TotalChanges = result.Summary.TotalChanges
+            }
+        };
+
+        // Group differences by change type for better organization
+        var addedItems = result.Differences.Where(d => d.ChangeType == ChangeType.Added).ToList();
+        var removedItems = result.Differences.Where(d => d.ChangeType == ChangeType.Removed).ToList();
+        var modifiedItems = result.Differences.Where(d => d.ChangeType == ChangeType.Modified).ToList();
+        var excludedItems = result.Differences.Where(d => d.ChangeType == ChangeType.Excluded).ToList();
+        var movedItems = result.Differences.Where(d => d.ChangeType == ChangeType.Moved).ToList();
+
+        // Convert differences to JSON model
+        jsonResult.Added = addedItems.Select(ConvertToJsonDifference).ToList();
+        jsonResult.Removed = removedItems.Select(ConvertToJsonDifference).ToList();
+        jsonResult.Modified = modifiedItems.Select(ConvertToJsonDifference).ToList();
+        jsonResult.Excluded = excludedItems.Select(ConvertToJsonDifference).ToList();
+        jsonResult.Moved = movedItems.Select(ConvertToJsonDifference).ToList();
+        
+        // Add breaking changes separately for easy access
+        jsonResult.BreakingChanges = result.Differences
+            .Where(d => d.IsBreakingChange)
+            .Select(ConvertToJsonDifference)
+            .ToList();
+
+        return jsonResult;
+    }
+
+    private static JsonApiDifference ConvertToJsonDifference(ApiDifference difference)
+    {
+        return new JsonApiDifference
+        {
+            ChangeType = difference.ChangeType.ToString(),
+            ElementType = difference.ElementType.ToString(),
+            ElementName = difference.ElementName,
+            Description = difference.Description,
+            IsBreakingChange = difference.IsBreakingChange,
+            Severity = difference.Severity.ToString(),
+            OldSignature = difference.OldSignature,
+            NewSignature = difference.NewSignature
+        };
+    }
+
+    #region JSON Models
+
+    /// <summary>
+    /// JSON-specific representation of a comparison result
+    /// </summary>
+    private class JsonComparisonResult
+    {
+        public string OldAssemblyPath { get; set; } = string.Empty;
+        public string NewAssemblyPath { get; set; } = string.Empty;
+        public DateTime ComparisonTimestamp { get; set; }
+        public bool HasBreakingChanges { get; set; }
+        public int TotalDifferences { get; set; }
+        public JsonComparisonSummary Summary { get; set; } = new();
+        public List<JsonApiDifference> Added { get; set; } = new();
+        public List<JsonApiDifference> Removed { get; set; } = new();
+        public List<JsonApiDifference> Modified { get; set; } = new();
+        public List<JsonApiDifference> Excluded { get; set; } = new();
+        public List<JsonApiDifference> Moved { get; set; } = new();
+        public List<JsonApiDifference> BreakingChanges { get; set; } = new();
+    }
+
+    /// <summary>
+    /// JSON-specific representation of comparison summary
+    /// </summary>
+    private class JsonComparisonSummary
+    {
+        public int AddedCount { get; set; }
+        public int RemovedCount { get; set; }
+        public int ModifiedCount { get; set; }
+        public int BreakingChangesCount { get; set; }
+        public int TotalChanges { get; set; }
+    }
+
+    /// <summary>
+    /// JSON-specific representation of an API difference
+    /// </summary>
+    private class JsonApiDifference
+    {
+        public string ChangeType { get; set; } = string.Empty;
+        public string ElementType { get; set; } = string.Empty;
+        public string ElementName { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public bool IsBreakingChange { get; set; }
+        public string Severity { get; set; } = string.Empty;
+        public string? OldSignature { get; set; }
+        public string? NewSignature { get; set; }
+    }
+
+    #endregion
+}

--- a/src/DotNetApiDiff/Reporting/JsonFormatter.cs
+++ b/src/DotNetApiDiff/Reporting/JsonFormatter.cs
@@ -107,16 +107,27 @@ public class JsonFormatter : IReportFormatter
     private class JsonComparisonResult
     {
         public string OldAssemblyPath { get; set; } = string.Empty;
+
         public string NewAssemblyPath { get; set; } = string.Empty;
+
         public DateTime ComparisonTimestamp { get; set; }
+
         public bool HasBreakingChanges { get; set; }
+
         public int TotalDifferences { get; set; }
+
         public JsonComparisonSummary Summary { get; set; } = new();
+
         public List<JsonApiDifference> Added { get; set; } = new();
+
         public List<JsonApiDifference> Removed { get; set; } = new();
+
         public List<JsonApiDifference> Modified { get; set; } = new();
+
         public List<JsonApiDifference> Excluded { get; set; } = new();
+
         public List<JsonApiDifference> Moved { get; set; } = new();
+
         public List<JsonApiDifference> BreakingChanges { get; set; } = new();
     }
 
@@ -126,9 +137,13 @@ public class JsonFormatter : IReportFormatter
     private class JsonComparisonSummary
     {
         public int AddedCount { get; set; }
+
         public int RemovedCount { get; set; }
+
         public int ModifiedCount { get; set; }
+
         public int BreakingChangesCount { get; set; }
+
         public int TotalChanges { get; set; }
     }
 
@@ -138,12 +153,19 @@ public class JsonFormatter : IReportFormatter
     private class JsonApiDifference
     {
         public string ChangeType { get; set; } = string.Empty;
+
         public string ElementType { get; set; } = string.Empty;
+
         public string ElementName { get; set; } = string.Empty;
+
         public string Description { get; set; } = string.Empty;
+
         public bool IsBreakingChange { get; set; }
+
         public string Severity { get; set; } = string.Empty;
+
         public string? OldSignature { get; set; }
+
         public string? NewSignature { get; set; }
     }
 

--- a/src/DotNetApiDiff/Reporting/JsonFormatter.cs
+++ b/src/DotNetApiDiff/Reporting/JsonFormatter.cs
@@ -36,7 +36,7 @@ public class JsonFormatter : IReportFormatter
     {
         // Create a JSON-friendly representation of the comparison result
         var jsonModel = CreateJsonModel(result);
-        
+
         // Serialize to JSON
         return JsonSerializer.Serialize(jsonModel, _jsonOptions);
     }
@@ -74,7 +74,7 @@ public class JsonFormatter : IReportFormatter
         jsonResult.Modified = modifiedItems.Select(ConvertToJsonDifference).ToList();
         jsonResult.Excluded = excludedItems.Select(ConvertToJsonDifference).ToList();
         jsonResult.Moved = movedItems.Select(ConvertToJsonDifference).ToList();
-        
+
         // Add breaking changes separately for easy access
         jsonResult.BreakingChanges = result.Differences
             .Where(d => d.IsBreakingChange)

--- a/tests/DotNetApiDiff.Tests/Reporting/JsonFormatterTests.cs
+++ b/tests/DotNetApiDiff.Tests/Reporting/JsonFormatterTests.cs
@@ -32,11 +32,11 @@ public class JsonFormatterTests
         // Assert
         Assert.NotNull(jsonOutput);
         Assert.NotEmpty(jsonOutput);
-        
+
         // Verify it's valid JSON
         var exception = Record.Exception(() => JsonDocument.Parse(jsonOutput));
         Assert.Null(exception);
-        
+
         // Verify basic content
         Assert.Contains("source.dll", jsonOutput);
         Assert.Contains("target.dll", jsonOutput);
@@ -76,14 +76,14 @@ public class JsonFormatterTests
 
         // Assert
         var root = jsonDoc.RootElement;
-        
+
         // Verify summary
         Assert.Equal(1, root.GetProperty("summary").GetProperty("addedCount").GetInt32());
-        
+
         // Verify added items
         var added = root.GetProperty("added");
         Assert.Equal(1, added.GetArrayLength());
-        
+
         var addedItem = added[0];
         Assert.Equal("Added", addedItem.GetProperty("changeType").GetString());
         Assert.Equal("Method", addedItem.GetProperty("elementType").GetString());
@@ -128,15 +128,15 @@ public class JsonFormatterTests
 
         // Assert
         var root = jsonDoc.RootElement;
-        
+
         // Verify summary
         Assert.Equal(1, root.GetProperty("summary").GetProperty("removedCount").GetInt32());
         Assert.Equal(1, root.GetProperty("summary").GetProperty("breakingChangesCount").GetInt32());
-        
+
         // Verify removed items
         var removed = root.GetProperty("removed");
         Assert.Equal(1, removed.GetArrayLength());
-        
+
         var removedItem = removed[0];
         Assert.Equal("Removed", removedItem.GetProperty("changeType").GetString());
         Assert.Equal("Method", removedItem.GetProperty("elementType").GetString());
@@ -145,7 +145,7 @@ public class JsonFormatterTests
         Assert.True(removedItem.GetProperty("isBreakingChange").GetBoolean());
         Assert.Equal("Error", removedItem.GetProperty("severity").GetString());
         Assert.Equal("public void OldMethod()", removedItem.GetProperty("oldSignature").GetString());
-        
+
         // Verify breaking changes section
         var breakingChanges = root.GetProperty("breakingChanges");
         Assert.Equal(1, breakingChanges.GetArrayLength());
@@ -186,15 +186,15 @@ public class JsonFormatterTests
 
         // Assert
         var root = jsonDoc.RootElement;
-        
+
         // Verify summary
         Assert.Equal(1, root.GetProperty("summary").GetProperty("modifiedCount").GetInt32());
         Assert.Equal(1, root.GetProperty("summary").GetProperty("breakingChangesCount").GetInt32());
-        
+
         // Verify modified items
         var modified = root.GetProperty("modified");
         Assert.Equal(1, modified.GetArrayLength());
-        
+
         var modifiedItem = modified[0];
         Assert.Equal("Modified", modifiedItem.GetProperty("changeType").GetString());
         Assert.Equal("Property", modifiedItem.GetProperty("elementType").GetString());
@@ -268,14 +268,14 @@ public class JsonFormatterTests
 
         // Assert
         var root = jsonDoc.RootElement;
-        
+
         // Verify summary
         Assert.Equal(1, root.GetProperty("summary").GetProperty("addedCount").GetInt32());
         Assert.Equal(1, root.GetProperty("summary").GetProperty("removedCount").GetInt32());
         Assert.Equal(1, root.GetProperty("summary").GetProperty("modifiedCount").GetInt32());
         Assert.Equal(2, root.GetProperty("summary").GetProperty("breakingChangesCount").GetInt32());
         Assert.Equal(3, root.GetProperty("summary").GetProperty("totalChanges").GetInt32());
-        
+
         // Verify sections exist with correct counts
         Assert.Equal(1, root.GetProperty("added").GetArrayLength());
         Assert.Equal(1, root.GetProperty("removed").GetArrayLength());
@@ -283,7 +283,7 @@ public class JsonFormatterTests
         Assert.Equal(1, root.GetProperty("excluded").GetArrayLength());
         Assert.Equal(2, root.GetProperty("breakingChanges").GetArrayLength());
     }
-    
+
     [Fact]
     public void Format_WithNonIndentedOption_ReturnsCompactJson()
     {
@@ -302,14 +302,14 @@ public class JsonFormatterTests
         // Assert
         Assert.NotNull(compactOutput);
         Assert.NotEmpty(compactOutput);
-        
+
         // Compact should be shorter than indented
         Assert.True(compactOutput.Length < indentedOutput.Length);
-        
+
         // But should contain the same data
         var indentedDoc = JsonDocument.Parse(indentedOutput);
         var compactDoc = JsonDocument.Parse(compactOutput);
-        
+
         Assert.Equal(
             indentedDoc.RootElement.GetProperty("oldAssemblyPath").GetString(),
             compactDoc.RootElement.GetProperty("oldAssemblyPath").GetString());

--- a/tests/DotNetApiDiff.Tests/Reporting/JsonFormatterTests.cs
+++ b/tests/DotNetApiDiff.Tests/Reporting/JsonFormatterTests.cs
@@ -1,0 +1,320 @@
+// Copyright DotNet API Diff Project Contributors - SPDX Identifier: MIT
+using DotNetApiDiff.Models;
+using DotNetApiDiff.Reporting;
+using System.Text.Json;
+using Xunit;
+
+namespace DotNetApiDiff.Tests.Reporting;
+
+public class JsonFormatterTests
+{
+    private readonly JsonFormatter _formatter;
+
+    public JsonFormatterTests()
+    {
+        _formatter = new JsonFormatter();
+    }
+
+    [Fact]
+    public void Format_WithEmptyResult_ReturnsValidJson()
+    {
+        // Arrange
+        var result = new ComparisonResult
+        {
+            OldAssemblyPath = "source.dll",
+            NewAssemblyPath = "target.dll",
+            ComparisonTimestamp = new DateTime(2023, 1, 1, 12, 0, 0, DateTimeKind.Utc)
+        };
+
+        // Act
+        var jsonOutput = _formatter.Format(result);
+
+        // Assert
+        Assert.NotNull(jsonOutput);
+        Assert.NotEmpty(jsonOutput);
+        
+        // Verify it's valid JSON
+        var exception = Record.Exception(() => JsonDocument.Parse(jsonOutput));
+        Assert.Null(exception);
+        
+        // Verify basic content
+        Assert.Contains("source.dll", jsonOutput);
+        Assert.Contains("target.dll", jsonOutput);
+        Assert.Contains("2023-01-01T12:00:00", jsonOutput);
+    }
+
+    [Fact]
+    public void Format_WithAddedItems_IncludesAddedSection()
+    {
+        // Arrange
+        var result = new ComparisonResult
+        {
+            OldAssemblyPath = "source.dll",
+            NewAssemblyPath = "target.dll",
+            Differences = new List<ApiDifference>
+            {
+                new ApiDifference
+                {
+                    ChangeType = ChangeType.Added,
+                    ElementType = ApiElementType.Method,
+                    ElementName = "System.String.NewMethod()",
+                    Description = "Method added",
+                    IsBreakingChange = false,
+                    Severity = SeverityLevel.Info,
+                    NewSignature = "public void NewMethod()"
+                }
+            },
+            Summary = new ComparisonSummary
+            {
+                AddedCount = 1
+            }
+        };
+
+        // Act
+        var jsonOutput = _formatter.Format(result);
+        var jsonDoc = JsonDocument.Parse(jsonOutput);
+
+        // Assert
+        var root = jsonDoc.RootElement;
+        
+        // Verify summary
+        Assert.Equal(1, root.GetProperty("summary").GetProperty("addedCount").GetInt32());
+        
+        // Verify added items
+        var added = root.GetProperty("added");
+        Assert.Equal(1, added.GetArrayLength());
+        
+        var addedItem = added[0];
+        Assert.Equal("Added", addedItem.GetProperty("changeType").GetString());
+        Assert.Equal("Method", addedItem.GetProperty("elementType").GetString());
+        Assert.Equal("System.String.NewMethod()", addedItem.GetProperty("elementName").GetString());
+        Assert.Equal("Method added", addedItem.GetProperty("description").GetString());
+        Assert.False(addedItem.GetProperty("isBreakingChange").GetBoolean());
+        Assert.Equal("Info", addedItem.GetProperty("severity").GetString());
+        Assert.Equal("public void NewMethod()", addedItem.GetProperty("newSignature").GetString());
+    }
+
+    [Fact]
+    public void Format_WithRemovedItems_IncludesRemovedSection()
+    {
+        // Arrange
+        var result = new ComparisonResult
+        {
+            OldAssemblyPath = "source.dll",
+            NewAssemblyPath = "target.dll",
+            Differences = new List<ApiDifference>
+            {
+                new ApiDifference
+                {
+                    ChangeType = ChangeType.Removed,
+                    ElementType = ApiElementType.Method,
+                    ElementName = "System.String.OldMethod()",
+                    Description = "Method removed",
+                    IsBreakingChange = true,
+                    Severity = SeverityLevel.Error,
+                    OldSignature = "public void OldMethod()"
+                }
+            },
+            Summary = new ComparisonSummary
+            {
+                RemovedCount = 1,
+                BreakingChangesCount = 1
+            }
+        };
+
+        // Act
+        var jsonOutput = _formatter.Format(result);
+        var jsonDoc = JsonDocument.Parse(jsonOutput);
+
+        // Assert
+        var root = jsonDoc.RootElement;
+        
+        // Verify summary
+        Assert.Equal(1, root.GetProperty("summary").GetProperty("removedCount").GetInt32());
+        Assert.Equal(1, root.GetProperty("summary").GetProperty("breakingChangesCount").GetInt32());
+        
+        // Verify removed items
+        var removed = root.GetProperty("removed");
+        Assert.Equal(1, removed.GetArrayLength());
+        
+        var removedItem = removed[0];
+        Assert.Equal("Removed", removedItem.GetProperty("changeType").GetString());
+        Assert.Equal("Method", removedItem.GetProperty("elementType").GetString());
+        Assert.Equal("System.String.OldMethod()", removedItem.GetProperty("elementName").GetString());
+        Assert.Equal("Method removed", removedItem.GetProperty("description").GetString());
+        Assert.True(removedItem.GetProperty("isBreakingChange").GetBoolean());
+        Assert.Equal("Error", removedItem.GetProperty("severity").GetString());
+        Assert.Equal("public void OldMethod()", removedItem.GetProperty("oldSignature").GetString());
+        
+        // Verify breaking changes section
+        var breakingChanges = root.GetProperty("breakingChanges");
+        Assert.Equal(1, breakingChanges.GetArrayLength());
+    }
+
+    [Fact]
+    public void Format_WithModifiedItems_IncludesModifiedSection()
+    {
+        // Arrange
+        var result = new ComparisonResult
+        {
+            OldAssemblyPath = "source.dll",
+            NewAssemblyPath = "target.dll",
+            Differences = new List<ApiDifference>
+            {
+                new ApiDifference
+                {
+                    ChangeType = ChangeType.Modified,
+                    ElementType = ApiElementType.Property,
+                    ElementName = "System.String.Length",
+                    Description = "Property type changed",
+                    IsBreakingChange = true,
+                    Severity = SeverityLevel.Critical,
+                    OldSignature = "public int Length { get; }",
+                    NewSignature = "public long Length { get; }"
+                }
+            },
+            Summary = new ComparisonSummary
+            {
+                ModifiedCount = 1,
+                BreakingChangesCount = 1
+            }
+        };
+
+        // Act
+        var jsonOutput = _formatter.Format(result);
+        var jsonDoc = JsonDocument.Parse(jsonOutput);
+
+        // Assert
+        var root = jsonDoc.RootElement;
+        
+        // Verify summary
+        Assert.Equal(1, root.GetProperty("summary").GetProperty("modifiedCount").GetInt32());
+        Assert.Equal(1, root.GetProperty("summary").GetProperty("breakingChangesCount").GetInt32());
+        
+        // Verify modified items
+        var modified = root.GetProperty("modified");
+        Assert.Equal(1, modified.GetArrayLength());
+        
+        var modifiedItem = modified[0];
+        Assert.Equal("Modified", modifiedItem.GetProperty("changeType").GetString());
+        Assert.Equal("Property", modifiedItem.GetProperty("elementType").GetString());
+        Assert.Equal("System.String.Length", modifiedItem.GetProperty("elementName").GetString());
+        Assert.Equal("Property type changed", modifiedItem.GetProperty("description").GetString());
+        Assert.True(modifiedItem.GetProperty("isBreakingChange").GetBoolean());
+        Assert.Equal("Critical", modifiedItem.GetProperty("severity").GetString());
+        Assert.Equal("public int Length { get; }", modifiedItem.GetProperty("oldSignature").GetString());
+        Assert.Equal("public long Length { get; }", modifiedItem.GetProperty("newSignature").GetString());
+    }
+
+    [Fact]
+    public void Format_WithMultipleChangeTypes_IncludesAllSections()
+    {
+        // Arrange
+        var result = new ComparisonResult
+        {
+            OldAssemblyPath = "source.dll",
+            NewAssemblyPath = "target.dll",
+            Differences = new List<ApiDifference>
+            {
+                new ApiDifference
+                {
+                    ChangeType = ChangeType.Added,
+                    ElementType = ApiElementType.Method,
+                    ElementName = "System.String.NewMethod()",
+                    Description = "Method added",
+                    IsBreakingChange = false,
+                    Severity = SeverityLevel.Info
+                },
+                new ApiDifference
+                {
+                    ChangeType = ChangeType.Removed,
+                    ElementType = ApiElementType.Method,
+                    ElementName = "System.String.OldMethod()",
+                    Description = "Method removed",
+                    IsBreakingChange = true,
+                    Severity = SeverityLevel.Error
+                },
+                new ApiDifference
+                {
+                    ChangeType = ChangeType.Modified,
+                    ElementType = ApiElementType.Property,
+                    ElementName = "System.String.Length",
+                    Description = "Property type changed",
+                    IsBreakingChange = true,
+                    Severity = SeverityLevel.Critical
+                },
+                new ApiDifference
+                {
+                    ChangeType = ChangeType.Excluded,
+                    ElementType = ApiElementType.Field,
+                    ElementName = "System.String._firstChar",
+                    Description = "Field excluded",
+                    IsBreakingChange = false,
+                    Severity = SeverityLevel.Info
+                }
+            },
+            Summary = new ComparisonSummary
+            {
+                AddedCount = 1,
+                RemovedCount = 1,
+                ModifiedCount = 1,
+                BreakingChangesCount = 2
+            }
+        };
+
+        // Act
+        var jsonOutput = _formatter.Format(result);
+        var jsonDoc = JsonDocument.Parse(jsonOutput);
+
+        // Assert
+        var root = jsonDoc.RootElement;
+        
+        // Verify summary
+        Assert.Equal(1, root.GetProperty("summary").GetProperty("addedCount").GetInt32());
+        Assert.Equal(1, root.GetProperty("summary").GetProperty("removedCount").GetInt32());
+        Assert.Equal(1, root.GetProperty("summary").GetProperty("modifiedCount").GetInt32());
+        Assert.Equal(2, root.GetProperty("summary").GetProperty("breakingChangesCount").GetInt32());
+        Assert.Equal(3, root.GetProperty("summary").GetProperty("totalChanges").GetInt32());
+        
+        // Verify sections exist with correct counts
+        Assert.Equal(1, root.GetProperty("added").GetArrayLength());
+        Assert.Equal(1, root.GetProperty("removed").GetArrayLength());
+        Assert.Equal(1, root.GetProperty("modified").GetArrayLength());
+        Assert.Equal(1, root.GetProperty("excluded").GetArrayLength());
+        Assert.Equal(2, root.GetProperty("breakingChanges").GetArrayLength());
+    }
+    
+    [Fact]
+    public void Format_WithNonIndentedOption_ReturnsCompactJson()
+    {
+        // Arrange
+        var compactFormatter = new JsonFormatter(indented: false);
+        var result = new ComparisonResult
+        {
+            OldAssemblyPath = "source.dll",
+            NewAssemblyPath = "target.dll"
+        };
+
+        // Act
+        var indentedOutput = _formatter.Format(result);
+        var compactOutput = compactFormatter.Format(result);
+
+        // Assert
+        Assert.NotNull(compactOutput);
+        Assert.NotEmpty(compactOutput);
+        
+        // Compact should be shorter than indented
+        Assert.True(compactOutput.Length < indentedOutput.Length);
+        
+        // But should contain the same data
+        var indentedDoc = JsonDocument.Parse(indentedOutput);
+        var compactDoc = JsonDocument.Parse(compactOutput);
+        
+        Assert.Equal(
+            indentedDoc.RootElement.GetProperty("oldAssemblyPath").GetString(),
+            compactDoc.RootElement.GetProperty("oldAssemblyPath").GetString());
+        Assert.Equal(
+            indentedDoc.RootElement.GetProperty("newAssemblyPath").GetString(),
+            compactDoc.RootElement.GetProperty("newAssemblyPath").GetString());
+    }
+}


### PR DESCRIPTION
## Description
This PR implements task 6.2 from the implementation plan - a JSON output formatter for the API comparison results.

The implementation includes:
- A new `JsonFormatter` class that implements the `IReportFormatter` interface
- Structured JSON output with categorized changes (added, removed, modified, excluded)
- Dedicated section for breaking changes for easy access
- Support for both indented and compact JSON output
- Comprehensive unit tests validating JSON structure and content

## Requirements Addressed
- 4.1: Output results in JSON format
- 4.2: Produce valid, structured JSON output suitable for programmatic consumption

## Testing
- Added unit tests that verify valid JSON output structure
- Tests for proper handling of different change types
- Tests for correct representation of breaking changes
- Tests for both formatting options (indented and compact)

## Related Issues
Closes task 6.2 from the implementation plan