### PR TITLE
Fix CompareCommandSettings parameterless constructor issue and improve integration tests

### DIFF
--- a/src/DotNetApiDiff/Commands/CompareCommand.cs
+++ b/src/DotNetApiDiff/Commands/CompareCommand.cs
@@ -19,11 +19,11 @@ public class CompareCommandSettings : CommandSettings
 {
     [CommandArgument(0, "<sourceAssembly>")]
     [Description("Path to the source/baseline assembly")]
-    required public string SourceAssemblyPath { get; init; }
+    public string? SourceAssemblyPath { get; init; }
 
     [CommandArgument(1, "<targetAssembly>")]
     [Description("Path to the target/current assembly")]
-    required public string TargetAssemblyPath { get; init; }
+    public string? TargetAssemblyPath { get; init; }
 
     [CommandOption("-c|--config <configFile>")]
     [Description("Path to configuration file")]
@@ -95,12 +95,22 @@ public class CompareCommand : Command<CompareCommandSettings>
     public override ValidationResult Validate([NotNull] CommandContext context, [NotNull] CompareCommandSettings settings)
     {
         // Validate source assembly path
+        if (string.IsNullOrEmpty(settings.SourceAssemblyPath))
+        {
+            return ValidationResult.Error("Source assembly path is required");
+        }
+
         if (!File.Exists(settings.SourceAssemblyPath))
         {
             return ValidationResult.Error($"Source assembly file not found: {settings.SourceAssemblyPath}");
         }
 
         // Validate target assembly path
+        if (string.IsNullOrEmpty(settings.TargetAssemblyPath))
+        {
+            return ValidationResult.Error("Target assembly path is required");
+        }
+
         if (!File.Exists(settings.TargetAssemblyPath))
         {
             return ValidationResult.Error($"Target assembly file not found: {settings.TargetAssemblyPath}");
@@ -203,7 +213,7 @@ public class CompareCommand : Command<CompareCommandSettings>
 
                     try
                     {
-                        sourceAssembly = assemblyLoader.LoadAssembly(settings.SourceAssemblyPath);
+                        sourceAssembly = assemblyLoader.LoadAssembly(settings.SourceAssemblyPath!);
                     }
                     catch (Exception ex)
                     {
@@ -216,7 +226,7 @@ public class CompareCommand : Command<CompareCommandSettings>
 
                     try
                     {
-                        targetAssembly = assemblyLoader.LoadAssembly(settings.TargetAssemblyPath);
+                        targetAssembly = assemblyLoader.LoadAssembly(settings.TargetAssemblyPath!);
                     }
                     catch (Exception ex)
                     {

--- a/tests/DotNetApiDiff.Tests/Integration/ConfigurationWorkflowTests.cs
+++ b/tests/DotNetApiDiff.Tests/Integration/ConfigurationWorkflowTests.cs
@@ -11,6 +11,7 @@ namespace DotNetApiDiff.Tests.Integration;
 /// <summary>
 /// Integration tests for configuration file workflows
 /// </summary>
+[Trait("Category", "Integration")]
 public class ConfigurationWorkflowTests : IDisposable
 {
     private readonly ITestOutputHelper _output;


### PR DESCRIPTION
## Problem

The CLI was failing with the error:
```
Could not resolve type 'DotNetApiDiff.Commands.CompareCommandSettings'.
System.MissingMethodException: Cannot dynamically create an instance of type 'DotNetApiDiff.Commands.CompareCommandSettings'. Reason: No parameterless constructor defined.
```

This was caused by the `required` keyword on properties in `CompareCommandSettings`, which prevents Spectre.Console.Cli from creating instances via the parameterless constructor.

## Root Cause Analysis

The issue wasn't caught by existing tests because:

1. **Unit tests bypassed the CLI layer** - They created `CompareCommandSettings` objects directly using object initializers
2. **Integration tests were silently skipping** - They had extensive skip logic that caused them to pass without actually testing the CLI
3. **Integration tests used incorrect syntax** - They called the CLI without the required `compare` command

## Solution

### Fixed the Constructor Issue
- Removed `required` keyword from `CompareCommandSettings` properties
- Made properties nullable and added proper validation in the `Validate` method
- Added null-forgiving operators in `Execute` method since validation ensures non-null values

### Improved Integration Tests
- Fixed all CLI calls to use correct `compare` command syntax
- Added proper test categories `[Trait("Category", "Integration")]`
- Fixed path resolution in `FindExecutablePath` method (5 levels up instead of 4)
- Replaced silent test skipping with proper assertions that fail when prerequisites aren't met
- Tests now properly detect issues instead of silently passing

## Testing

- ✅ All 345 tests pass (318 unit + 27 integration)
- ✅ Integration tests can be run with `task test:integration`
- ✅ CLI now works correctly: `dotnet run -- compare source.dll target.dll`
- ✅ Original failing command now works properly

## Files Changed

- `src/DotNetApiDiff/Commands/CompareCommand.cs` - Fixed constructor issue
- `tests/DotNetApiDiff.Tests/Integration/CliWorkflowTests.cs` - Fixed CLI syntax and test robustness
- `tests/DotNetApiDiff.Tests/Integration/ConfigurationWorkflowTests.cs` - Added test category

This fix ensures the CLI works correctly and that integration tests will catch similar issues in the future.