### PR TITLE
Fix HTML escaping for generic type parameters in reports

### DIFF
--- a/src/DotNetApiDiff/Reporting/HtmlFormatterScriban.cs
+++ b/src/DotNetApiDiff/Reporting/HtmlFormatterScriban.cs
@@ -64,6 +64,21 @@ public class HtmlFormatterScriban : IReportFormatter
         return _mainTemplate.Render(context);
     }
 
+    private static string HtmlEscape(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return input ?? string.Empty;
+        }
+
+        return input
+            .Replace("&", "&amp;")
+            .Replace("<", "&lt;")
+            .Replace(">", "&gt;")
+            .Replace("\"", "&quot;")
+            .Replace("'", "&#39;");
+    }
+
     private object PrepareConfigData(ComparisonConfiguration config)
     {
         var namespaceMappings = config?.Mappings?.NamespaceMappings ?? new Dictionary<string, List<string>>();
@@ -236,19 +251,6 @@ public class HtmlFormatterScriban : IReportFormatter
                     details_id = $"details-{Guid.NewGuid():N}"
                 }).ToArray()
             }).ToArray();
-    }
-
-    private static string HtmlEscape(string? input)
-    {
-        if (string.IsNullOrEmpty(input))
-            return input ?? string.Empty;
-
-        return input
-            .Replace("&", "&amp;")
-            .Replace("<", "&lt;")
-            .Replace(">", "&gt;")
-            .Replace("\"", "&quot;")
-            .Replace("'", "&#39;");
     }
 
     private object[] PrepareBreakingChangesData(IEnumerable<ApiDifference> breakingChanges)

--- a/src/DotNetApiDiff/Reporting/HtmlFormatterScriban.cs
+++ b/src/DotNetApiDiff/Reporting/HtmlFormatterScriban.cs
@@ -231,11 +231,24 @@ public class HtmlFormatterScriban : IReportFormatter
                     description = c.Description,
                     is_breaking_change = c.IsBreakingChange,
                     has_signatures = !string.IsNullOrEmpty(c.OldSignature) || !string.IsNullOrEmpty(c.NewSignature),
-                    old_signature = c.OldSignature,
-                    new_signature = c.NewSignature,
+                    old_signature = HtmlEscape(c.OldSignature),
+                    new_signature = HtmlEscape(c.NewSignature),
                     details_id = $"details-{Guid.NewGuid():N}"
                 }).ToArray()
             }).ToArray();
+    }
+
+    private static string HtmlEscape(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return input ?? string.Empty;
+
+        return input
+            .Replace("&", "&amp;")
+            .Replace("<", "&lt;")
+            .Replace(">", "&gt;")
+            .Replace("\"", "&quot;")
+            .Replace("'", "&#39;");
     }
 
     private object[] PrepareBreakingChangesData(IEnumerable<ApiDifference> breakingChanges)

--- a/tests/DotNetApiDiff.Tests/Reporting/HtmlFormatterScribanTests.cs
+++ b/tests/DotNetApiDiff.Tests/Reporting/HtmlFormatterScribanTests.cs
@@ -181,6 +181,43 @@ public class HtmlFormatterScribanTests
         Assert.Contains("public void ChangedMethod(string param)", report);
     }
 
+    [Fact]
+    public void Format_WithGenericTypeSignatures_ProperlyEscapesHtml()
+    {
+        // Arrange
+        var result = new ComparisonResult
+        {
+            OldAssemblyPath = "source.dll",
+            NewAssemblyPath = "target.dll",
+            ComparisonTimestamp = new DateTime(2023, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+            Configuration = CreateDefaultConfiguration(),
+            Differences = new List<ApiDifference>
+            {
+                new ApiDifference
+                {
+                    ChangeType = ChangeType.Added,
+                    ElementType = ApiElementType.Method,
+                    ElementName = "Execute",
+                    Description = "Added method with generic parameters",
+                    NewSignature = "public ValkeyResult Execute(string command, ICollection<object> args)",
+                    Severity = SeverityLevel.Info
+                }
+            }
+        };
+
+        // Act
+        var report = _formatter.Format(result);
+
+        // Assert
+        Assert.NotNull(report);
+        Assert.Contains("Added Items", report);
+        Assert.Contains("Execute", report);
+        // Verify that generic type parameters are properly HTML-escaped
+        Assert.Contains("ICollection&lt;object&gt;", report);
+        // Verify that unescaped angle brackets are not present
+        Assert.DoesNotContain("ICollection<object>", report);
+    }
+
     private static ComparisonConfiguration CreateDefaultConfiguration()
     {
         return new ComparisonConfiguration


### PR DESCRIPTION
## Problem

HTML reports were breaking when displaying API signatures containing generic type parameters. For example, signatures like `ICollection<object>` were being interpreted by browsers as HTML `<object>` tags instead of being displayed as intended C# code.

This caused the HTML structure to become malformed and prevented proper rendering of the reports.

## Solution

- **Added `HtmlEscape` method**: Properly encodes special HTML characters (`&`, `<`, `>`, `"`, `'`) to their HTML entity equivalents
- **Updated `GroupChanges` method**: Applied HTML escaping to both `old_signature` and `new_signature` values before template rendering
- **Comprehensive test coverage**: Added test case specifically for generic type HTML escaping to prevent regression

## Changes

### Modified Files
- `src/DotNetApiDiff/Reporting/HtmlFormatterScriban.cs`
  - Added `HtmlEscape` static method with comprehensive character encoding
  - Updated signature handling in `GroupChanges` to escape HTML entities
- `tests/DotNetApiDiff.Tests/Reporting/HtmlFormatterScribanTests.cs`
  - Added `Format_WithGenericTypeSignatures_ProperlyEscapesHtml` test method
  - Verifies proper escaping of `ICollection<object>` to `ICollection&lt;object&gt;`

## Testing

The fix has been validated with:
- ✅ Unit test specifically for generic type escaping
- ✅ Manual verification through regenerated HTML reports
- ✅ Browser rendering confirmation showing proper display

## Impact

- **Before**: Generic types like `ICollection<object>` broke HTML structure
- **After**: Generic types display correctly as `ICollection&lt;object&gt;` in browsers
- **Risk**: Low - only affects display formatting, no functional logic changes

This fix ensures that all API signatures with generic type parameters are properly displayed in HTML reports without breaking the document structure.